### PR TITLE
Add Splash V1 datum schemas

### DIFF
--- a/projects/SplashV1/basicPoolDatum.cddl
+++ b/projects/SplashV1/basicPoolDatum.cddl
@@ -1,0 +1,14 @@
+BasicPoolDatum = #6.121([ poolNft : Asset
+                        , poolX : Asset
+                        , poolY : Asset
+                        , poolLq : Asset
+                        , poolFeeNum : int
+                        , unspecifiedField : BytesSingletonArray
+                        , nonce : int
+                        ])
+
+Asset = #6.121([ policyId : bytes
+               , tokenName : bytes
+               ])
+
+BytesSingletonArray = [bytes]

--- a/projects/SplashV1/depositDatum.cddl
+++ b/projects/SplashV1/depositDatum.cddl
@@ -1,0 +1,19 @@
+DepositDatum = #6.121([ poolNft : Asset
+                      , tokenA : Asset
+                      , tokenB : Asset
+                      , tokenLp : Asset
+                      , exFee : int
+                      , rewardPkh : bytes
+                      , stakePkh : MaybePubKeyHash
+                      , collateralAda : int
+                      ])
+
+Asset = #6.121([ policyId : bytes
+               , tokenName : bytes
+               ])
+
+MaybePubKeyHash = JustPubKeyHash / Nothing
+
+JustPubKeyHash = #6.121([bytes])
+
+Nothing = #6.122([])

--- a/projects/SplashV1/limitOrderDatum.cddl
+++ b/projects/SplashV1/limitOrderDatum.cddl
@@ -1,0 +1,37 @@
+LimitOrderDatum = #6.121([ tag : bytes
+                         , beacon : bytes
+                         , input : Asset
+                         , tradableInput : int
+                         , costPerExStep : int
+                         , minMarginalOutput : int
+                         , output : Asset
+                         , basePrice : Rational
+                         , fee : int
+                         , redeemerAddress : Address
+                         , cancellationPkh : bytes
+                         , permittedExecutors : BytesSingletonArray
+                         ])
+
+Asset = #6.121([ policyId : bytes
+               , tokenName : bytes
+               ])
+
+BytesSingletonArray = [bytes]
+
+Rational = #6.121([ num: int
+                  , denom: int
+                  ])
+
+Address = #6.121([ paymentCredential: Credential
+                 , maybeStakeCredential : StakeCredential / None
+                 ])
+
+Credential = KeyCredential / ScriptCredential
+
+KeyCredential = #6.121([bytes])
+
+ScriptCredential = #6.122([bytes])
+
+StakeCredential = #6.121([#6.121([ Credential ])])
+
+None = #6.122([])

--- a/projects/SplashV1/redeemDatum.cddl
+++ b/projects/SplashV1/redeemDatum.cddl
@@ -1,0 +1,18 @@
+RedeemDatum = #6.121([ poolNft : Asset
+                     , poolX : Asset
+                     , poolY : Asset
+                     , poolLp : Asset
+                     , exFee : int
+                     , rewardPkh : bytes
+                     , stakePkh : MaybePubKeyHash
+                     ])
+
+Asset = #6.121([ policyId : bytes
+               , tokenName : bytes
+               ])
+
+MaybePubKeyHash = JustPubKeyHash / Nothing
+
+JustPubKeyHash = #6.121([bytes])
+
+Nothing = #6.122([])

--- a/projects/SplashV1/royaltyPoolDatum.cddl
+++ b/projects/SplashV1/royaltyPoolDatum.cddl
@@ -1,0 +1,32 @@
+RoyaltyPoolDatum = #6.121([ poolNft : Asset
+                          , poolX : Asset
+                          , poolY : Asset
+                          , poolLq : Asset
+                          , poolFeeNum : int
+                          , treasuryFee : int
+                          , royaltyFee : int
+                          , treasuryX : int
+                          , treasuryY : int
+                          , royaltyX : int
+                          , royaltyY : int
+                          , daoPolicy : DaoPolicy
+                          , treasuryAddress : ValidatorHash
+                          , royaltyPubKey : bytes
+                          , nonce : int
+                          ])
+
+Asset = #6.121([ policyId : bytes
+               , tokenName : bytes
+               ])
+
+DaoPolicy = [StakingCredential]
+
+StakingCredential = #6.121([Credential])
+
+Credential = KeyCredential / ScriptCredential
+
+KeyCredential = #6.121([bytes])
+
+ScriptCredential = #6.122([bytes])
+
+ValidatorHash = bytes

--- a/projects/SplashV1/treasuryPoolDatum.cddl
+++ b/projects/SplashV1/treasuryPoolDatum.cddl
@@ -1,0 +1,28 @@
+TreasuryPoolDatum = #6.121([ poolNft : Asset
+                           , poolX : Asset
+                           , poolY : Asset
+                           , poolLq : Asset
+                           , poolFeeNum : int
+                           , treasuryFee : int
+                           , treasuryX : int
+                           , treasuryY : int
+                           , daoPolicy : DaoPolicy
+                           , lqBound : int
+                           , treasuryAddress : ValidatorHash
+                           ])
+
+Asset = #6.121([ policyId : bytes
+               , tokenName : bytes
+               ])
+
+DaoPolicy = [StakingCredential]
+
+StakingCredential = #6.121([Credential])
+
+Credential = KeyCredential / ScriptCredential
+
+KeyCredential = #6.121([bytes])
+
+ScriptCredential = #6.122([bytes])
+
+ValidatorHash = bytes


### PR DESCRIPTION
Pool datum:

- basicPoolDatum
  - https://github.com/spectrum-finance/cardano-dex-contracts/blob/master/cardano-dex-contracts-onchain/ErgoDex/Contracts/Pool.hs

- treasuryPoolDatum
  - same as BasicPoolDatum, extended with treasury fields
  - https://github.com/splashprotocol/splash-core/blob/main/plutarch-validators/WhalePoolsDex/Contracts/Pool.hs

- royaltyPoolDatum
   - same as TreasuryPoolDatum, extended with royalty fields
   - https://github.com/splashprotocol/splash-core/blob/main/plutarch-validators/WhalePoolsDex/Contracts/RoyaltyPool.hs

Order datum:

- limitOrderDatum:
  - https://github.com/splashprotocol/splash-core/blob/main/validators/orders/limit_order.ak

- depositDatum
  - https://github.com/splashprotocol/splash-core/blob/main/plutarch-validators/WhalePoolsDex/Contracts/Proxy/Deposit.hs

- redeemDatum:
  - https://github.com/splashprotocol/splash-core/blob/main/plutarch-validators/WhalePoolsDex/Contracts/Proxy/Redeem.hs

